### PR TITLE
Feature/alternative ports

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3,7 +3,8 @@
 #include "parson.h"
 
 TConfig config = (TConfig){
-  .server_ip     = "127.0.0.1",
+  .bind_ip       = "127.0.0.1",
+  .bind_port     = 53,
   .upstream_ip   = "8.8.8.8",
   .upstream_port = 53,
   .cache_time    = 6*3600,
@@ -85,8 +86,15 @@ void config_parse(JSON_Value *cfg) {
   if (cfg_type != JSONObject) return;
   cfg_obj = json_value_get_object(cfg);
 
-  if (json_object_has_value_of_type(cfg_obj, "server_ip", JSONString)) {
-    config.server_ip = strdup(json_object_get_string(cfg_obj, "server_ip"));
+  if (json_object_has_value_of_type(cfg_obj, "bind", JSONString)) {
+    str_tmp  = strdup(json_object_get_string(cfg_obj, "bind"));
+    str_ip   = strtok(str_tmp, "#");
+    str_port = strtok(NULL   , "#");
+
+    config.bind_ip = str_ip;
+
+    if (str_port) u16_port = atoi(str_port);
+    if (u16_port) config.bind_port = u16_port;
   }
 
   if (json_object_has_value_of_type(cfg_obj, "upstream", JSONString)) {

--- a/src/config.c
+++ b/src/config.c
@@ -3,10 +3,11 @@
 #include "parson.h"
 
 TConfig config = (TConfig){
-  .server_ip   = "127.0.0.1",
-  .dns         = "8.8.8.8",
-  .cache_time  = 6*3600,
-  .debug_level = 0,
+  .server_ip     = "127.0.0.1",
+  .upstream_ip   = "8.8.8.8",
+  .upstream_port = 53,
+  .cache_time    = 6*3600,
+  .debug_level   = 0,
 };
 
 char rr_buf[0xFFF] = {0};
@@ -75,6 +76,11 @@ void config_parse(JSON_Value *cfg) {
   JSON_Object     *cfg_obj = NULL;
   JSON_Value_Type  cfg_type = json_value_get_type(cfg);
 
+  char *str_tmp;
+  char *str_ip;
+  char *str_port;
+  uint16_t u16_port = 0;
+
   // Basic type checking
   if (cfg_type != JSONObject) return;
   cfg_obj = json_value_get_object(cfg);
@@ -83,8 +89,15 @@ void config_parse(JSON_Value *cfg) {
     config.server_ip = strdup(json_object_get_string(cfg_obj, "server_ip"));
   }
 
-  if (json_object_has_value_of_type(cfg_obj, "dns", JSONString)) {
-    config.dns = strdup(json_object_get_string(cfg_obj, "dns"));
+  if (json_object_has_value_of_type(cfg_obj, "upstream", JSONString)) {
+    str_tmp  = strdup(json_object_get_string(cfg_obj, "upstream"));
+    str_ip   = strtok(str_tmp, "#");
+    str_port = strtok(NULL   , "#");
+
+    config.upstream_ip = str_ip;
+
+    if (str_port) u16_port = atoi(str_port);
+    if (u16_port) config.upstream_port = u16_port;
   }
 
   if (json_object_has_value_of_type(cfg_obj, "cache_time", JSONNumber)) {

--- a/src/config.h
+++ b/src/config.h
@@ -2,8 +2,9 @@
 
 typedef struct TConfig
 {
-  char     *server_ip;
+  char     *bind_ip;
   char     *upstream_ip;
+  uint16_t  bind_port;
   uint16_t  upstream_port;
   uint32_t  cache_time;
   uint8_t   debug_level;

--- a/src/config.h
+++ b/src/config.h
@@ -3,7 +3,8 @@
 typedef struct TConfig
 {
   char     *server_ip;
-  char     *dns;
+  char     *upstream_ip;
+  uint16_t  upstream_port;
   uint32_t  cache_time;
   uint8_t   debug_level;
 } TConfig;

--- a/src/main.c
+++ b/src/main.c
@@ -32,8 +32,8 @@ void loop(int sockfd)
 
   memset((char *) &out_addr, 0, sizeof(out_addr));
   out_addr.sin_family = AF_INET;
-  out_addr.sin_port   = htons(DNS_PORT);
-  inet_aton(config.dns, (struct in_addr *)&out_addr.sin_addr.s_addr);
+  out_addr.sin_port   = htons(config.upstream_port);
+  inet_aton(config.upstream_ip, (struct in_addr *)&out_addr.sin_addr.s_addr);
   out_socket = socket(AF_INET, SOCK_DGRAM, 0);
   if (out_socket < 0) error("ERROR opening socket out");
 

--- a/src/main.c
+++ b/src/main.c
@@ -4,7 +4,6 @@
 
 #include "argparse.h"
 
-#define DNS_PORT 53
 #define VERSION  "0.3.1"
 
 static const char *const usages[] = {
@@ -144,12 +143,12 @@ int server_init()
 
   // convert domain to IP
   char buf[0xFF];
-  if (hostname_to_ip(config.server_ip, buf, sizeof(buf)))
-    config.server_ip = buf;
+  if (hostname_to_ip(config.bind_ip, buf, sizeof(buf)))
+    config.bind_ip = buf;
 
   // is ipv6?
   int is_ipv6 = 0, i = 0;
-  while (config.server_ip[i]) if (config.server_ip[i++] == ':') { is_ipv6 = 1; break; }
+  while (config.bind_ip[i]) if (config.bind_ip[i++] == ':') { is_ipv6 = 1; break; }
 
   // create socket
   sock = socket(is_ipv6 ? AF_INET6 : AF_INET, SOCK_DGRAM, 0);
@@ -169,8 +168,8 @@ int server_init()
     struct sockaddr_in6 serveraddr;  /* server's addr */
     memset((char *) &serveraddr, 0, sizeof(serveraddr));
     serveraddr.sin6_family = AF_INET6;
-    serveraddr.sin6_port   = htons(DNS_PORT);
-    inet_pton(AF_INET6, config.server_ip, (struct in_addr *)&serveraddr.sin6_addr.s6_addr);
+    serveraddr.sin6_port   = htons(config.bind_port);
+    inet_pton(AF_INET6, config.bind_ip, (struct in_addr *)&serveraddr.sin6_addr.s6_addr);
     if (bind(sock, (struct sockaddr *) &serveraddr, sizeof(serveraddr)) < 0)
       error("ERROR on binding ipv6");
   }
@@ -179,14 +178,14 @@ int server_init()
     struct sockaddr_in serveraddr;  /* server's addr */
     memset((char *) &serveraddr, 0, sizeof(serveraddr));
     serveraddr.sin_family = AF_INET;
-    serveraddr.sin_port   = htons(DNS_PORT);
-    inet_aton(config.server_ip, (struct in_addr *)&serveraddr.sin_addr.s_addr);
+    serveraddr.sin_port   = htons(config.bind_port);
+    inet_aton(config.bind_ip, (struct in_addr *)&serveraddr.sin_addr.s_addr);
     if (bind(sock, (struct sockaddr *) &serveraddr, sizeof(serveraddr)) < 0)
       error("ERROR on binding ipv4");
   }
 
   char s[0xFF];
-  sprintf(s, "bind on %s:%d", config.server_ip, DNS_PORT);
+  sprintf(s, "bind on %s:%d", config.bind_ip, config.bind_port);
   log_s(s);
 
   return sock;

--- a/tinydns.conf
+++ b/tinydns.conf
@@ -1,5 +1,5 @@
 {
-  "server_ip"  : "127.0.0.1",
+  "bind"       : "127.0.0.1#53",
   "upstream"   : "8.8.8.8#53",
   "cache_time" : 43200,
   "debug_level": 1,

--- a/tinydns.conf
+++ b/tinydns.conf
@@ -1,8 +1,8 @@
 {
-  "server_ip":  "127.0.0.1",
-  "dns":        "8.8.8.8",
-  "cache_time":  43200,
-  "debug_level": 0,
+  "server_ip"  : "127.0.0.1",
+  "upstream"   : "8.8.8.8#53",
+  "cache_time" : 43200,
+  "debug_level": 1,
   "rr": {
     "domain.example.com": "127.0.0.1",
        "_.*.example.com": "127.0.0.2",

--- a/tinydns.conf
+++ b/tinydns.conf
@@ -2,7 +2,7 @@
   "bind"       : "127.0.0.1#53",
   "upstream"   : "8.8.8.8#53",
   "cache_time" : 43200,
-  "debug_level": 1,
+  "debug_level": 0,
   "rr": {
     "domain.example.com": "127.0.0.1",
        "_.*.example.com": "127.0.0.2",


### PR DESCRIPTION
Implements:
- #1
- #5

---

Adds alternative port support for both the bound address and the upstream server, and renames the configuration fields to match those more specific descriptors.